### PR TITLE
Fix log information for pthread_attr_setstacksize

### DIFF
--- a/src/po_hi_task.c
+++ b/src/po_hi_task.c
@@ -559,7 +559,7 @@ pthread_t __po_hi_posix_create_thread(
 
   if (stack_size != 0) {
     if (pthread_attr_setstacksize(&attr, stack_size) != 0) {
-      __PO_HI_DEBUG_CRITICAL ("Thread creation failed - in call to pthread_attr_setscope\n");
+      __PO_HI_DEBUG_CRITICAL ("Thread creation failed - in call to pthread_attr_setstacksize\n");
       return ((pthread_t) __PO_HI_ERROR_PTHREAD_ATTR);
     }
   }


### PR DESCRIPTION
# Description

There was a typo in the error message for `pthread_attr_setstacksize`. Although the error occurred in that function, the message complained about `pthread_attr_setscope`.

# Changes

Now when the user will not get confused with errors related to the stack size of a task.

# Tested on

-   Raspberry Pi 4B
-   OS: Raspberry Pi OS (Debian v11, bullseye)